### PR TITLE
use lowercase gotest everywhere

### DIFF
--- a/filter/reader_test.go
+++ b/filter/reader_test.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	testutils "github.com/jpfielding/goTest/testutils"
+	testutils "github.com/jpfielding/gotest/testutils"
 )
 
 func TestFilter(t *testing.T) {

--- a/filter/xml_test.go
+++ b/filter/xml_test.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"testing"
 
-	testutils "github.com/jpfielding/goTest/testutils"
+	testutils "github.com/jpfielding/gotest/testutils"
 )
 
 func TestBadXml(t *testing.T) {


### PR DESCRIPTION
to avoid confusing go tool dep on case insensitive filesystems